### PR TITLE
fix: iOS simulator

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,11 +143,11 @@ const previewEmail = async (message, options) => {
         return booted;
       });
 
-      // let done = false;
+      let done = false;
       const server = http.createServer((req, res) => {
         pEvent(res, 'close').then(() => {
           debug('end');
-          // done = true;
+          done = true;
         });
         debug('request made');
         res.writeHead(200, { 'Content-Type': 'text/html' });
@@ -164,6 +164,7 @@ const previewEmail = async (message, options) => {
         });
       });
 
+      /*
       const emlFilePath = `${options.dir}/${options.id}.eml`;
       await writeFile(emlFilePath, raw);
       debug('emlFilePath', emlFilePath);
@@ -186,14 +187,14 @@ const previewEmail = async (message, options) => {
         });
       });
 
-      /*
       const v = await cryptoRandomString({ length: 10, type: 'alphanumeric' });
+      */
 
       const xcrun = childProcess.spawn('xcrun', [
         'simctl',
         'openurl',
         'booted',
-        `http://127.0.0.1:${port}/?v=${v}#html`
+        `http://127.0.0.1:${port}/#html`
       ]);
       await new Promise((resolve, reject) => {
         xcrun.once('error', reject);
@@ -209,7 +210,6 @@ const previewEmail = async (message, options) => {
       });
 
       await pWaitFor(() => done);
-      */
 
       // display notification
       await displayNotification({


### PR DESCRIPTION
Uncomment the code that opens `http://127.0.0.1:${port}/#html` as I am unable to open `.eml` file in the iOS simulator.

```shell
$ xcrun simctl openurl booted /var/folders/1t/ktc77qxs4k711pb_6cz8547w0000gn/T/e045a5cf-f88c-425c-b1d6-f9b60fa9a77c.eml
An error was encountered processing the command (domain=NSOSStatusErrorDomain, code=-50):
Simulator device returned an error for the requested operation.
Underlying error (domain=NSOSStatusErrorDomain, code=-50):
	The operation couldn’t be completed. (OSStatus error -50.)
```

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
