### PR TITLE
fix: allow to open links in email preview

### DIFF
--- a/template.pug
+++ b/template.pug
@@ -120,4 +120,4 @@ html
         input(type='radio', name='preview_email', checked=!html)#tab-text
         label(for='tab-text') Plain text
         .preview-email-tab
-          iframe(sandbox='', referrerpolicy='no-referrer', seamless='seamless', srcdoc=`<pre>${text}</pre>`)#text
+          iframe(sandbox='allow-popups', referrerpolicy='no-referrer', seamless='seamless', srcdoc=`<pre>${text}</pre>`)#text


### PR DESCRIPTION
## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

closes #36

Chrome blocks clicking on links inside an iframe with `sandbox` attribute without `allow-popups`.
![image](https://github.com/forwardemail/test-preview-emails-cross-browsers-ios-simulator-nodejs-javascript/assets/9304194/06dc1d2a-7e81-43f8-a016-6d33d7c54a87)
